### PR TITLE
attempting to modify code to support Angular2's

### DIFF
--- a/syntaxes/typescriptAngular2.tmLanguage
+++ b/syntaxes/typescriptAngular2.tmLanguage
@@ -1407,7 +1407,7 @@
 		<key>template-ng</key>
 		<dict>
 			<key>begin</key>
-			<string>\(`</string>
+			<string>template: `</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>0</key>
@@ -1417,7 +1417,7 @@
 				</dict>
 			</dict>
 			<key>end</key>
-			<string>`\)</string>
+			<string>`</string>
 			<key>endCaptures</key>
 			<dict>
 				<key>0</key>


### PR DESCRIPTION
    template: `<html/>`
instead of 
    (``<html/>``)

Not sure if the code can support multiple cases?.. (such as ```template:`<html/>` with no space, and parenthesis as well)

as mentioned in issue https://github.com/iservices/language-vscode-javascript-angular2/issues/1